### PR TITLE
Add typing to imlib.cells

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,17 @@
 repos:
 -   repo: https://github.com/python/black
-    rev: 19.10b0
+    rev: 23.3.0
     hooks:
     - id: black
       pass_filenames: true
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+-   repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
     hooks:
     - id: flake8
       pass_filenames: true
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.4.0
+    hooks:
+    -   id: mypy
+        args: [--config-file, pyproject.toml]
+        additional_dependencies: [numpy]

--- a/imlib/IO/cells.py
+++ b/imlib/IO/cells.py
@@ -8,6 +8,7 @@ Christian Niedworok (https://github.com/cniedwor).
 import logging
 import os
 import yaml
+from typing import List, Optional
 
 import pandas as pd
 
@@ -24,7 +25,11 @@ from imlib.cells.cells import (
 from imlib.general.system import replace_extension
 
 
-def get_cells(cells_file_path, cells_only=False, cell_type=None):
+def get_cells(
+    cells_file_path: str,
+    cells_only: bool = False,
+    cell_type: Optional[int] = None,
+):
     # TODO: implement csv read
     if cells_file_path.endswith(".xml"):
         return get_cells_xml(cells_file_path, cells_only=cells_only)
@@ -136,7 +141,7 @@ def cells_xml_to_df(xml_file_path):
     return cells_to_dataframe(cells)
 
 
-def cells_to_dataframe(cells):
+def cells_to_dataframe(cells: List[Cell]) -> pd.DataFrame:
     return pd.DataFrame([c.to_dict() for c in cells])
 
 

--- a/imlib/cells/cells.py
+++ b/imlib/cells/cells.py
@@ -5,10 +5,12 @@ Christian Niedworok (https://github.com/cniedwor).
 import os
 import re
 import math
+from typing import Union, Dict, List, Tuple, Any, Optional
 
 from functools import total_ordering
 from collections import defaultdict
 
+import numpy.typing as npt
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element as EtElement
 
@@ -16,7 +18,7 @@ import logging
 
 
 @total_ordering
-class Cell(object):
+class Cell:
     ARTIFACT = -1
     CELL = 2
     UNKNOWN = 1
@@ -24,7 +26,11 @@ class Cell(object):
     # for classification compatibility
     NO_CELL = 1
 
-    def __init__(self, pos, cell_type):
+    def __init__(
+        self,
+        pos: Union[str, ElementTree.Element, Dict[str, float], List[float]],
+        cell_type: int,
+    ):
         if isinstance(pos, str):
             pos = pos_from_file_name(os.path.basename(pos))
         if isinstance(pos, ElementTree.Element):
@@ -33,15 +39,18 @@ class Cell(object):
             pos = pos_from_dict(pos)
         pos = self._sanitize_position(pos)
         x, y, z = [int(p) for p in pos]
-        self.x = x
-        self.y = y
-        self.z = z
+        self.x: float = x
+        self.y: float = y
+        self.z: float = z
 
-        self.transformed_x, self.transformed_y, self.transformed_z = x, y, z
+        self.transformed_x: float = x
+        self.transformed_y: float = y
+        self.transformed_z: float = z
 
         self.structure_id = None
         self.hemisphere = None
 
+        self.type: int
         if cell_type is None:
             self.type = Cell.UNKNOWN
         elif str(cell_type).lower() == "cell":
@@ -51,7 +60,9 @@ class Cell(object):
         else:
             self.type = int(cell_type)
 
-    def _sanitize_position(self, pos, verbose=True):
+    def _sanitize_position(
+        self, pos: List[float], verbose: bool = True
+    ) -> List[float]:
         out = []
         for coord in pos:
             if math.isnan(coord):
@@ -66,14 +77,14 @@ class Cell(object):
 
     def _transform(
         self,
-        x_scale=1.0,
-        y_scale=1.0,
-        z_scale=1.0,
-        x_offset=0,
-        y_offset=0,
-        z_offset=0,
-        integer=False,
-    ):
+        x_scale: float = 1.0,
+        y_scale: float = 1.0,
+        z_scale: float = 1.0,
+        x_offset: float = 0,
+        y_offset: float = 0,
+        z_offset: float = 0,
+        integer: bool = False,
+    ) -> Tuple[float, float, float]:
         x = self.x
         y = self.y
         z = self.z
@@ -87,20 +98,20 @@ class Cell(object):
         z *= z_scale
 
         if integer:
-            return [int(round(e)) for e in (x, y, z)]
+            return int(round(x)), int(round(y)), int(round(z))
         else:
             return x, y, z
 
     def transform(
         self,
-        x_scale=1.0,
-        y_scale=1.0,
-        z_scale=1.0,
-        x_offset=0,
-        y_offset=0,
-        z_offset=0,
-        integer=False,
-    ):
+        x_scale: float = 1.0,
+        y_scale: float = 1.0,
+        z_scale: float = 1.0,
+        x_offset: float = 0,
+        y_offset: float = 0,
+        z_offset: float = 0,
+        integer: bool = False,
+    ) -> None:
         transformed_coords = self._transform(
             x_scale, y_scale, z_scale, x_offset, y_offset, z_offset, integer
         )
@@ -108,14 +119,14 @@ class Cell(object):
 
     def soft_transform(
         self,
-        x_scale=1.0,
-        y_scale=1.0,
-        z_scale=1.0,
-        x_offset=0,
-        y_offset=0,
-        z_offset=0,
-        integer=False,
-    ):
+        x_scale: float = 1.0,
+        y_scale: float = 1.0,
+        z_scale: float = 1.0,
+        x_offset: float = 0,
+        y_offset: float = 0,
+        z_offset: float = 0,
+        integer: bool = False,
+    ) -> None:
         transformed_coords = self._transform(
             x_scale, y_scale, z_scale, x_offset, y_offset, z_offset, integer
         )
@@ -125,13 +136,13 @@ class Cell(object):
             self.transformed_z,
         ) = transformed_coords
 
-    def flip_x_y(self):
+    def flip_x_y(self) -> None:
         self.y, self.x = self.x, self.y
 
-    def is_cell(self):
+    def is_cell(self) -> bool:
         return self.type == Cell.CELL
 
-    def to_xml_element(self):
+    def to_xml_element(self) -> EtElement:
         sub_elements = [EtElement("Marker{}".format(axis)) for axis in "XYZ"]
         coords = [int(coord) for coord in (self.x, self.y, self.z)]
         for sub_element, coord in zip(sub_elements, coords):
@@ -147,7 +158,7 @@ class Cell(object):
         element.extend(sub_elements)
         return element
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         if not isinstance(other, self.__class__):
             return False
         return (self.x, self.y, self.z, self.type) == (
@@ -157,10 +168,10 @@ class Cell(object):
             other.type,
         )
 
-    def __ne__(self, other):
+    def __ne__(self, other: Any) -> bool:
         return not (self == other)
 
-    def __lt__(self, other):
+    def __lt__(self, other: Any) -> Union[bool, NotImplementedError]:
         if self == other:
             return False
         try:
@@ -183,61 +194,70 @@ class Cell(object):
                 )
             )
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "Cell: x: {}, y: {}, z: {}, type: {}".format(
             int(self.x), int(self.y), int(self.z), self.type
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "{}, ({}, {})".format(
             self.__class__, [self.x, self.y, self.z], self.type
         )
 
-    def to_dict(self):
+    def to_dict(self) -> Dict[str, float]:
         return {"x": self.x, "y": self.y, "z": self.z, "type": self.type}
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(str(self))
 
 
 class UntypedCell(Cell):
-    def __init__(self, pos):
+    def __init__(
+        self,
+        pos: Union[str, ElementTree.Element, Dict[str, float], List[float]],
+    ) -> None:
         super(UntypedCell, self).__init__(pos, self.UNKNOWN)
 
     @property
-    def type(self):
+    def type(self) -> int:
         return self.UNKNOWN
 
     @type.setter
-    def type(self, value):
+    def type(self, value: int) -> None:
         pass
 
     @classmethod
-    def from_cell(cls, cell):
+    def from_cell(cls, cell: Cell) -> "UntypedCell":
         return cls([cell.x, cell.y, cell.z])
 
-    def to_cell(self):
+    def to_cell(self) -> Cell:
         return Cell([self.x, self.y, self.z], self.type)
 
 
-def pos_from_dict(position_dict):
+def pos_from_dict(position_dict: Dict[str, float]) -> List[float]:
     return [position_dict["x"], position_dict["y"], position_dict["z"]]
 
 
-def pos_from_xml_marker(element):
+def pos_from_xml_marker(element: ElementTree.Element) -> List[float]:
     marker_names = ["Marker{}".format(axis) for axis in "XYZ"]
-    pos = [element.find(marker_name).text for marker_name in marker_names]
-    return [float(num) for num in pos]
+    markers = [element.find(marker_name) for marker_name in marker_names]
+    pos = [marker.text for marker in markers if marker is not None]
+    return [float(num) for num in pos if num is not None]
 
 
-def pos_from_file_name(file_name):
+def pos_from_file_name(file_name: str) -> List[float]:
     x = re.findall(r"x\d+", file_name.lower())
     y = re.findall(r"y\d+", file_name.lower())
     z = re.findall(r"z\d+", file_name.lower())
     return [int(p) for p in (x[-1][1:], y[-1][1:], z[-1][1:])]
 
 
-def transform(cell, deformation_field, field_scales, scales):
+def transform(
+    cell: Cell,
+    deformation_field: npt.NDArray[Any],
+    field_scales: Tuple[float, float, float],
+    scales: Tuple[float, float, float],
+) -> Optional[Cell]:
     """
     Transforms cell position from one space, to another (defined by a
     deformation field)
@@ -287,9 +307,10 @@ def transform(cell, deformation_field, field_scales, scales):
 
     except IndexError:
         warn_outside_target_space(cell)
+        return None
 
 
-def warn_outside_target_space(cell):
+def warn_outside_target_space(cell: Cell) -> None:
     logging.warning(
         "Position x:{}, y:{}, z{} is outside the target "
         "coordinate space, skipping. If this happens for many "
@@ -298,8 +319,11 @@ def warn_outside_target_space(cell):
 
 
 def transform_cell_positions(
-    cells, deformation_field, field_scales=(100, 100, 100), scales=(1, 1, 1)
-):
+    cells: List[Cell],
+    deformation_field: npt.NDArray[Any],
+    field_scales: Tuple[float, float, float] = (100, 100, 100),
+    scales: Tuple[float, float, float] = (1, 1, 1),
+) -> List[Cell]:
     """
     Transforms cell positions from one space, to another (defined by a
     deformation field)
@@ -322,17 +346,19 @@ def transform_cell_positions(
     ]
 
     # Remove None's from list (where cell couldn't be transformed)
-    transformed_cells = [cell for cell in transformed_cells if cell]
-    cells_not_transformed = len(cells) - len(transformed_cells)
+    transformed_cells_no_none = [
+        cell for cell in transformed_cells if cell is not None
+    ]
+    cells_not_transformed = len(cells) - len(transformed_cells_no_none)
     logging.warning(
         "{} cells were not transformed to standard space".format(
             cells_not_transformed
         )
     )
-    return transformed_cells
+    return transformed_cells_no_none
 
 
-def group_cells_by_z(cells):
+def group_cells_by_z(cells: List[Cell]) -> Dict[float, List[Cell]]:
     """
     For a list of Cells return a dict of lists of cells, grouped by plane.
 
@@ -344,7 +370,7 @@ def group_cells_by_z(cells):
     cells_groups = defaultdict(list)
     for cell in cells:
         cells_groups[cell.z].append(cell)
-    return cells_groups
+    return dict(cells_groups)
 
 
 class MissingCellsError(Exception):

--- a/imlib/cells/utils.py
+++ b/imlib/cells/utils.py
@@ -1,16 +1,21 @@
 import logging
+from typing import Union, Tuple, Any
+
+import numpy.typing as npt
 
 import imlib.IO.cells as cell_io
 from imlib.cells.cells import Cell
 
 
 def get_cell_location_array(
-    cell_file,
-    cell_position_scaling=[None, None, None],
-    cells_only=False,
-    type_str="type",
-    integer=True,
-):
+    cell_file: str,
+    cell_position_scaling: Union[
+        Tuple[None, None, None], Tuple[float, float, float]
+    ] = (None, None, None),
+    cells_only: bool = False,
+    type_str: str = "type",
+    integer: bool = True,
+) -> npt.NDArray[Any]:
     """
     Loads a cell file, and converts to an array, with 3 columns of x,y,z
     positions
@@ -29,7 +34,7 @@ def get_cell_location_array(
     logging.debug("Loading cells")
     cells = cell_io.get_cells(cell_file)
 
-    if cell_position_scaling != [None, None, None]:
+    if cell_position_scaling != (None, None, None):
         for cell in cells:
             cell.transform(
                 x_scale=cell_position_scaling[0],
@@ -50,4 +55,4 @@ def get_cell_location_array(
 
     logging.debug("Tidying up dataframe to convert to array")
     cells.drop(type_str, axis=1, inplace=True)
-    return cells.to_numpy()
+    return cells.to_numpy()  # type: ignore[no-any-return]

--- a/imlib/general/system.py
+++ b/imlib/general/system.py
@@ -226,10 +226,10 @@ def disk_free_gb(file_path):
     if platform.system() == "Windows":
         drive, _ = os.path.splitdrive(file_path)
         total, used, free = shutil.disk_usage(drive)
-        return free / 1024 ** 3
+        return free / 1024**3
     else:
         stats = os.statvfs(file_path)
-        return (stats.f_frsize * stats.f_bavail) / 1024 ** 3
+        return (stats.f_frsize * stats.f_bavail) / 1024**3
 
 
 def get_free_ram():

--- a/imlib/image/scale.py
+++ b/imlib/image/scale.py
@@ -10,7 +10,7 @@ def scale_to_16_bits(img):
     :rtype: np.array
     """
     normalised = img / img.max()
-    return normalised * (2 ** 16 - 1)
+    return normalised * (2**16 - 1)
 
 
 def scale_and_convert_to_16_bits(img):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,11 @@ exclude = '''
   | dist
 )/
 '''
+
+[tool.mypy]
+ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = ["imlib.cells.*"]
+ignore_errors = false
+strict = true

--- a/tests/tests/test_unit/test_general/test_system.py
+++ b/tests/tests/test_unit/test_general/test_system.py
@@ -46,7 +46,6 @@ def test_remove_leading_character():
 
 
 def test_ensure_directory_exists(tmpdir):
-
     # string
     exist_dir = os.path.join(tmpdir, "test_dir")
     system.ensure_directory_exists(exist_dir)

--- a/tests/tests/test_unit/test_radial/test_radial_misc.py
+++ b/tests/tests/test_unit/test_radial/test_radial_misc.py
@@ -29,51 +29,45 @@ def test_opposite_angle():
 
 
 def test_radial_bins():
-    assert (
-        np.array(
-            [
-                0,
-                25,
-                50,
-                75,
-                100,
-                125,
-                150,
-                175,
-                200,
-                225,
-                250,
-                275,
-                300,
-                325,
-                350,
-                375,
-            ]
-        )
-        == pytest.approx(misc.radial_bins(25))
-    )
-    assert (
-        np.array(
-            [
-                0,
-                25,
-                50,
-                75,
-                100,
-                125,
-                150,
-                175,
-                200,
-                225,
-                250,
-                275,
-                300,
-                325,
-                350,
-            ]
-        )
-        == pytest.approx(misc.radial_bins(25, remove_greater_than_360=True))
-    )
+    assert np.array(
+        [
+            0,
+            25,
+            50,
+            75,
+            100,
+            125,
+            150,
+            175,
+            200,
+            225,
+            250,
+            275,
+            300,
+            325,
+            350,
+            375,
+        ]
+    ) == pytest.approx(misc.radial_bins(25))
+    assert np.array(
+        [
+            0,
+            25,
+            50,
+            75,
+            100,
+            125,
+            150,
+            175,
+            200,
+            225,
+            250,
+            275,
+            300,
+            325,
+            350,
+        ]
+    ) == pytest.approx(misc.radial_bins(25, remove_greater_than_360=True))
 
     assert np.array([0, 3.45575192, 6.91150384]) == pytest.approx(
         misc.radial_bins(1.1 * np.pi, degrees=False)


### PR DESCRIPTION
Since `Cell` is used by quite a lot of packages downstream, I figured it was worth adding typing to it. This PR:

- Adds `mypy` to pre-commit config
- Adds strict typing to everything under `imlib.cells`.